### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,8 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
-    oddjob: "https://github.com/simp/pupmod-simp-oddjob"
+    concat: "https://github.com/simp/puppetlabs-concat.git"
+    oddjob: "https://github.com/simp/pupmod-simp-oddjob.git"
     pam: "https://github.com/simp/pupmod-simp-pam.git"
     stdlib: "https://github.com/simp/puppetlabs-stdlib.git"
     simplib: "https://github.com/simp/pupmod-simp-simplib.git"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.1
+- Fix a bad URL in the README.md
+- Expand the range of stdlib Puppet module versions required in metadata.json
+
 * Wed Oct 31 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.1.0
 - asset updates to make sure puppet 5 tests are running.
 

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ SIMP Puppet modules are generally intended for use on Red Hat Enterprise Linux a
 
 ## Development
 
-Please read our [Contribution Guide] (http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-cron",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing cron",
   "license": "Apache-2.0",
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Fix bad URL in README.md
- Expand range of stdlib Puppet module version in metadata.json, 
  since the tests are using a 5.X version

SIMP-6213 #comment pupmod-simp-cron