### PR TITLE
(SIMP-7848) Add PE2019.8 to pupmod-simp-cron GL pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,14 +3,14 @@
 # ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
-# https://puppet.com/docs/pe/2019.5/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/2019.8/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
-# Release       Puppet   Ruby   EOL
-# SIMP 6.4      5.5      2.4.5  TBD
-# PE 2018.1     5.5      2.4.5  2020-11 (LTS)
-# PE 2019.5     6.14     2.5.7  Quarterly
+# Release       Puppet   Ruby    EOL
+# SIMP 6.4      5.5      2.4.10  TBD
+# PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
+# PE 2019.8     6.16     2.5.7   2021-11 (LTS)
 ---
 stages:
   - 'sanity'
@@ -80,6 +80,13 @@ variables:
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
+.pup_6_16_0: &pup_6_16_0
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '6.16.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -157,6 +164,10 @@ pup6-unit:
   <<: *pup_6
   <<: *unit_tests
 
+pup6.16.0-unit:
+  <<: *pup_6_16_0
+  <<: *unit_tests
+
 # Repo-specific content
 # ==============================================================================
 
@@ -202,3 +213,28 @@ pup6-compliance:
   <<: *compliance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
+
+pup6.16.0:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites'
+
+pup6.16.0-fips:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+
+pup6.16.0-oel:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,oel]'
+
+pup6.16.0-oel-fips:
+  <<: *pup_6_16_0
+  <<: *acceptance_base
+  <<: *only_with_SIMP_FULL_MATRIX
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
         - true
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-        - '[[ $TRAVIS_TAG =~ ^poxvup-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
         - 'gem install -v "~> 5.5.0" puppet'
         - 'git clean -f -x -d'
         - 'puppet module build'


### PR DESCRIPTION
This patch updates the puppet and ruby versions in the Gitlab CI
pipeline to reflect the latest PE LTS releases.  Most notably, it adds
specific tests for PE2019.8 LTS.

SIMP-7869 #close
[SIMP-7848] #comment Add PE2019.8 to GL CI in pupmod-simp-cron
[SIMP-7855] #comment Update GL CI to PE2018.1.15 in pupmod-simp-cron

[SIMP-7848]: https://simp-project.atlassian.net/browse/SIMP-7848
[SIMP-7855]: https://simp-project.atlassian.net/browse/SIMP-7855