### PR TITLE
[puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 0.8.0
-- [puppetsync] Add EL9 support
+* Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 0.8.0
+- [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 
 * Wed Jan 17 2024 Richard Gardner <rick@sicura.us> - 0.7.1
 - Updated hiera.yaml facts to support puppet 8

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 0.8.0
+- [puppetsync] Add EL9 support
+
 * Wed Jan 17 2024 Richard Gardner <rick@sicura.us> - 0.7.1
 - Updated hiera.yaml facts to support puppet 8
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-cron",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing cron",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "optional_dependencies": [
       {
         "name": "simp/pam",
-        "version_requirement": ">= 6.8.3 < 7.0.0"
+        "version_requirement": ">= 6.8.3 < 8.0.0"
       }
     ]
   },


### PR DESCRIPTION
The patch enforces a standardized asset baseline using
simp/puppetsync, and may also apply other updates to
ensure conformity.